### PR TITLE
【docker部署】更改npm镜像源至最新

### DIFF
--- a/web/Dockerfile-build
+++ b/web/Dockerfile-build
@@ -5,7 +5,7 @@ WORKDIR /web
 COPY . .
 
 # 设置淘宝npm镜像
-RUN npm config set registry https://registry.npm.taobao.org 
+RUN npm config set registry https://registry.npmmirror.com 
 # 安装pnpm
 RUN npm install -g pnpm
 # 安装依赖


### PR DESCRIPTION
旧taobao镜像源已不可用
更改为https://registry.npmmirror.com